### PR TITLE
feat: lag til persistens for tokenbruk

### DIFF
--- a/src/main/kotlin/no/josefus/abuhint/configuration/OpenAiTokenUsageListener.kt
+++ b/src/main/kotlin/no/josefus/abuhint/configuration/OpenAiTokenUsageListener.kt
@@ -7,6 +7,8 @@ import dev.langchain4j.model.chat.listener.ChatModelResponseContext
 import dev.langchain4j.model.openai.OpenAiTokenUsage
 import no.josefus.abuhint.service.ChatIdContextHolder
 import no.josefus.abuhint.service.TokenUsageEntry
+import no.josefus.abuhint.service.TokenUsageContext
+import no.josefus.abuhint.service.TokenUsageContextHolder
 import no.josefus.abuhint.service.TokenUsageStore
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -20,17 +22,24 @@ class OpenAiTokenUsageListener(
 
     companion object {
         private const val CHAT_ID_ATTR = "chatId"
+        private const val USAGE_CONTEXT_ATTR = "tokenUsageContext"
     }
 
     override fun onRequest(requestContext: ChatModelRequestContext) {
-        val chatId = ChatIdContextHolder.get()
+        val usageContext = TokenUsageContextHolder.get()
+        if (usageContext != null) {
+            requestContext.attributes()[USAGE_CONTEXT_ATTR] = usageContext
+        }
+
+        val chatId = usageContext?.chatId ?: ChatIdContextHolder.get()
         if (chatId != null) {
             requestContext.attributes()[CHAT_ID_ATTR] = chatId
         }
     }
 
     override fun onResponse(responseContext: ChatModelResponseContext) {
-        val chatId = responseContext.attributes()[CHAT_ID_ATTR] as? String
+        val usageContext = responseContext.attributes()[USAGE_CONTEXT_ATTR] as? TokenUsageContext
+        val chatId = usageContext?.chatId ?: responseContext.attributes()[CHAT_ID_ATTR] as? String
         if (chatId == null) {
             log.debug("No chatId in listener context; skipping token usage recording")
             return
@@ -47,16 +56,29 @@ class OpenAiTokenUsageListener(
             0
         }
 
-        tokenUsageStore.record(chatId, TokenUsageEntry(
+        val entry = TokenUsageEntry(
             inputTokens = inputTokens,
             cachedInputTokens = cachedTokens,
             outputTokens = outputTokens,
             modelName = modelName,
-        ))
+        )
+
+        if (usageContext != null) {
+            tokenUsageStore.record(usageContext, entry)
+        } else {
+            tokenUsageStore.record(chatId, entry)
+        }
 
         log.info(
-            "Token usage for chatId={}: input={} (cached={}) output={} model={}",
-            chatId, inputTokens, cachedTokens, outputTokens, modelName,
+            "Token usage for userId={} chatId={} assistant={} platform={}: input={} (cached={}) output={} model={}",
+            usageContext?.userId ?: "unknown",
+            chatId,
+            usageContext?.assistant ?: "unknown",
+            usageContext?.clientPlatform ?: "unknown",
+            inputTokens,
+            cachedTokens,
+            outputTokens,
+            modelName,
         )
     }
 

--- a/src/main/kotlin/no/josefus/abuhint/controller/ChatController.kt
+++ b/src/main/kotlin/no/josefus/abuhint/controller/ChatController.kt
@@ -14,11 +14,16 @@ import dev.langchain4j.data.message.UserMessage
 import no.josefus.abuhint.dto.ChatHistoryMessage
 import no.josefus.abuhint.dto.ChatHistoryResponse
 import no.josefus.abuhint.dto.OpenAiCompatibleContentItem
-import no.josefus.abuhint.dto.TokenUsageResponse
+import no.josefus.abuhint.dto.TokenUsageBreakdownResponse
+import no.josefus.abuhint.dto.TokenUsageSummaryResponse
 import no.josefus.abuhint.service.ChatService
+import no.josefus.abuhint.service.TokenUsageBreakdown
+import no.josefus.abuhint.service.TokenUsageContext
+import no.josefus.abuhint.service.TokenUsageSummary
 import no.josefus.abuhint.service.TokenUsageStore
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.util.UUID
@@ -30,6 +35,9 @@ class ChatController(
     private val chatService: ChatService,
     private val tokenUsageStore: TokenUsageStore,
 ) {
+    companion object {
+        const val CLIENT_PLATFORM_HEADER = "X-Client-Platform"
+    }
 
     @Operation(
         summary = "Send melding til Abu-hint",
@@ -88,10 +96,15 @@ class ChatController(
     fun sendMessage(
         @RequestParam(required = false) chatId: String?,
         @RequestParam(required = false) credentials: String?,
+        @RequestHeader(value = CLIENT_PLATFORM_HEADER, required = false) clientPlatform: String? = null,
         @RequestBody message: MessageRequest,
     ): ResponseEntity<List<OpenAiCompatibleContentItem>> {
         val sessionId = chatId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
-        val reply = chatService.processChat(sessionId, message.message)
+        val reply = chatService.processChat(
+            sessionId,
+            message.message,
+            usageContext(sessionId, "ABUHINT", clientPlatform),
+        )
         val contentItems = listOf(OpenAiCompatibleContentItem(type = "text", text = reply))
         return ResponseEntity.ok(contentItems)
     }
@@ -103,10 +116,15 @@ class ChatController(
     @PostMapping(value = ["/stream"], produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     fun streamMessage(
         @RequestParam(required = false) chatId: String?,
+        @RequestHeader(value = CLIENT_PLATFORM_HEADER, required = false) clientPlatform: String? = null,
         @RequestBody message: MessageRequest,
     ): SseEmitter {
         val sessionId = chatId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
-        return chatService.processChatStream(sessionId, message.message)
+        return chatService.processChatStream(
+            sessionId,
+            message.message,
+            usageContext(sessionId, "ABUHINT", clientPlatform),
+        )
     }
 
     @Operation(
@@ -156,7 +174,7 @@ class ChatController(
                 description = "Tokenforbruk for samtalen",
                 content = [Content(
                     mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = Schema(implementation = TokenUsageResponse::class),
+                    schema = Schema(implementation = TokenUsageSummaryResponse::class),
                     examples = [ExampleObject(
                         name = "Eksempel",
                         value = """{"chatId":"3fa85f64-5717-4562-b3fc-2c963f66afa6","inputTokens":2048,"cachedInputTokens":1024,"outputTokens":512,"totalTokens":2560,"requestCount":3,"modelName":"configured-in-application-yml"}""",
@@ -167,9 +185,11 @@ class ChatController(
         ],
     )
     @GetMapping("/usage/{chatId}", produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun getTokenUsage(@PathVariable chatId: String): ResponseEntity<TokenUsageResponse> {
-        val usage = tokenUsageStore.getUsage(chatId)
-            ?: return ResponseEntity.notFound().build()
+    fun getTokenUsage(@PathVariable chatId: String): ResponseEntity<TokenUsageSummaryResponse> {
+        val usage = tokenUsageStore.getUsageForUserChat(currentUserId(), chatId)
+        if (usage.breakdown.isEmpty()) {
+            return ResponseEntity.notFound().build()
+        }
         return ResponseEntity.ok(usage.toResponse())
     }
 
@@ -182,26 +202,52 @@ class ChatController(
                 description = "Liste over tokenforbruk for alle samtaler",
                 content = [Content(
                     mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    array = ArraySchema(schema = Schema(implementation = TokenUsageResponse::class)),
+                    schema = Schema(implementation = TokenUsageSummaryResponse::class),
                 )],
             ),
         ],
     )
     @GetMapping("/usage", produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun getAllTokenUsage(): ResponseEntity<List<TokenUsageResponse>> {
-        val all = tokenUsageStore.getAllUsage().values.map { it.toResponse() }
-        return ResponseEntity.ok(all)
+    fun getAllTokenUsage(): ResponseEntity<TokenUsageSummaryResponse> {
+        val usage = tokenUsageStore.getUsageForUser(currentUserId())
+        return ResponseEntity.ok(usage.toResponse())
     }
 
-    private fun no.josefus.abuhint.service.TokenUsageRecord.toResponse() = TokenUsageResponse(
-        chatId = chatId,
-        inputTokens = inputTokens.get(),
-        cachedInputTokens = cachedInputTokens.get(),
-        outputTokens = outputTokens.get(),
-        totalTokens = inputTokens.get() + outputTokens.get(),
-        requestCount = requestCount.get(),
-        modelName = lastModelName,
+    private fun TokenUsageSummary.toResponse() = TokenUsageSummaryResponse(
+        userId = userId,
+        inputTokens = inputTokens,
+        cachedInputTokens = cachedInputTokens,
+        outputTokens = outputTokens,
+        totalTokens = totalTokens,
+        requestCount = requestCount,
+        breakdown = breakdown.map { it.toResponse() },
     )
+
+    private fun TokenUsageBreakdown.toResponse() = TokenUsageBreakdownResponse(
+        chatId = chatId,
+        assistant = assistant,
+        clientPlatform = clientPlatform,
+        modelName = modelName,
+        inputTokens = inputTokens,
+        cachedInputTokens = cachedInputTokens,
+        outputTokens = outputTokens,
+        totalTokens = totalTokens,
+        requestCount = requestCount,
+        updatedAt = updatedAt.toString(),
+    )
+
+    private fun usageContext(chatId: String, assistant: String, clientPlatform: String?) = TokenUsageContext(
+        userId = currentUserId(),
+        chatId = chatId,
+        assistant = assistant,
+        clientPlatform = clientPlatform.normalizedPlatform(),
+    )
+
+    private fun currentUserId(): String =
+        SecurityContextHolder.getContext().authentication?.name
+            ?: throw IllegalStateException("No authenticated user in SecurityContext")
+
+    private fun String?.normalizedPlatform(): String = this?.trim()?.takeIf { it.isNotBlank() } ?: "unknown"
 
     @Schema(description = "Forespørsel med brukerens melding")
     data class MessageRequest(

--- a/src/main/kotlin/no/josefus/abuhint/controller/CoachAssistantController.kt
+++ b/src/main/kotlin/no/josefus/abuhint/controller/CoachAssistantController.kt
@@ -11,11 +11,14 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import no.josefus.abuhint.dto.ChatRequest
 import no.josefus.abuhint.dto.OpenAiCompatibleContentItem
 import no.josefus.abuhint.service.ChatService
+import no.josefus.abuhint.service.TokenUsageContext
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -75,10 +78,15 @@ class CoachAssistantController(
     @PostMapping("/chat", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun chat(
         @RequestParam(required = false) chatId: String?,
+        @RequestHeader(value = ChatController.CLIENT_PLATFORM_HEADER, required = false) clientPlatform: String? = null,
         @RequestBody message: ChatRequest,
     ): ResponseEntity<List<OpenAiCompatibleContentItem>> {
         val sessionId = chatId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
-        val reply = chatService.processChat(sessionId, message.message)
+        val reply = chatService.processChat(
+            sessionId,
+            message.message,
+            usageContext(sessionId, "COACH", clientPlatform),
+        )
         val contentItems = listOf(OpenAiCompatibleContentItem(type = "text", text = reply))
         return ResponseEntity.ok(contentItems)
     }
@@ -90,9 +98,22 @@ class CoachAssistantController(
     @PostMapping("/chat/stream", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     fun chatStream(
         @RequestParam(required = false) chatId: String?,
+        @RequestHeader(value = ChatController.CLIENT_PLATFORM_HEADER, required = false) clientPlatform: String? = null,
         @RequestBody message: ChatRequest,
     ): SseEmitter {
         val sessionId = chatId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
-        return chatService.processChatStream(sessionId, message.message)
+        return chatService.processChatStream(
+            sessionId,
+            message.message,
+            usageContext(sessionId, "COACH", clientPlatform),
+        )
     }
+
+    private fun usageContext(chatId: String, assistant: String, clientPlatform: String?) = TokenUsageContext(
+        userId = SecurityContextHolder.getContext().authentication?.name
+            ?: throw IllegalStateException("No authenticated user in SecurityContext"),
+        chatId = chatId,
+        assistant = assistant,
+        clientPlatform = clientPlatform?.trim()?.takeIf { it.isNotBlank() } ?: "unknown",
+    )
 }

--- a/src/main/kotlin/no/josefus/abuhint/controller/OpenAiCompatibleController.kt
+++ b/src/main/kotlin/no/josefus/abuhint/controller/OpenAiCompatibleController.kt
@@ -11,9 +11,11 @@ import no.josefus.abuhint.dto.OpenAiCompatibleChatCompletionResponse
 import no.josefus.abuhint.service.OpenAiCompatibleService
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 
@@ -128,9 +130,14 @@ class OpenAiCompatibleController(
     )
     @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
     fun createChatCompletion(
+        @RequestHeader(value = ChatController.CLIENT_PLATFORM_HEADER, required = false) clientPlatform: String? = null,
         @RequestBody request: OpenAiCompatibleChatCompletionRequest,
     ): ResponseEntity<OpenAiCompatibleChatCompletionResponse> {
-        val response = openAiCompatibleService.createChatCompletion(request)
+        val response = openAiCompatibleService.createChatCompletion(
+            request,
+            currentUserId(),
+            clientPlatform.normalizedPlatform(),
+        )
         return ResponseEntity.ok(response)
     }
 
@@ -140,8 +147,19 @@ class OpenAiCompatibleController(
     )
     @PostMapping("/stream", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     fun createStreamingChatCompletion(
+        @RequestHeader(value = ChatController.CLIENT_PLATFORM_HEADER, required = false) clientPlatform: String? = null,
         @RequestBody request: OpenAiCompatibleChatCompletionRequest,
     ): SseEmitter {
-        return openAiCompatibleService.createStreamingChatCompletion(request)
+        return openAiCompatibleService.createStreamingChatCompletion(
+            request,
+            currentUserId(),
+            clientPlatform.normalizedPlatform(),
+        )
     }
+
+    private fun currentUserId(): String =
+        SecurityContextHolder.getContext().authentication?.name
+            ?: throw IllegalStateException("No authenticated user in SecurityContext")
+
+    private fun String?.normalizedPlatform(): String = this?.trim()?.takeIf { it.isNotBlank() } ?: "unknown"
 }

--- a/src/main/kotlin/no/josefus/abuhint/controller/TechAdvisorController.kt
+++ b/src/main/kotlin/no/josefus/abuhint/controller/TechAdvisorController.kt
@@ -11,8 +11,10 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import no.josefus.abuhint.dto.ChatRequest
 import no.josefus.abuhint.dto.OpenAiCompatibleContentItem
 import no.josefus.abuhint.service.ChatService
+import no.josefus.abuhint.service.TokenUsageContext
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.util.UUID
@@ -77,10 +79,15 @@ class TechAdvisorController(
     @PostMapping("/chat", produces = [MediaType.APPLICATION_JSON_VALUE])
     fun chat(
         @RequestParam(required = false) chatId: String?,
+        @RequestHeader(value = ChatController.CLIENT_PLATFORM_HEADER, required = false) clientPlatform: String? = null,
         @RequestBody message: ChatRequest,
     ): ResponseEntity<List<OpenAiCompatibleContentItem>> {
         val sessionId = chatId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
-        val reply = chatService.processGeminiChat(sessionId, message.message)
+        val reply = chatService.processGeminiChat(
+            sessionId,
+            message.message,
+            usageContext(sessionId, "TECH_ADVISOR", clientPlatform),
+        )
         val contentItems = listOf(OpenAiCompatibleContentItem(type = "text", text = reply))
         return ResponseEntity.ok(contentItems)
     }
@@ -92,9 +99,22 @@ class TechAdvisorController(
     @PostMapping("/chat/stream", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     fun chatStream(
         @RequestParam(required = false) chatId: String?,
+        @RequestHeader(value = ChatController.CLIENT_PLATFORM_HEADER, required = false) clientPlatform: String? = null,
         @RequestBody message: ChatRequest,
     ): SseEmitter {
         val sessionId = chatId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
-        return chatService.processGeminiChatStream(sessionId, message.message)
+        return chatService.processGeminiChatStream(
+            sessionId,
+            message.message,
+            usageContext(sessionId, "TECH_ADVISOR", clientPlatform),
+        )
     }
+
+    private fun usageContext(chatId: String, assistant: String, clientPlatform: String?) = TokenUsageContext(
+        userId = SecurityContextHolder.getContext().authentication?.name
+            ?: throw IllegalStateException("No authenticated user in SecurityContext"),
+        chatId = chatId,
+        assistant = assistant,
+        clientPlatform = clientPlatform?.trim()?.takeIf { it.isNotBlank() } ?: "unknown",
+    )
 }

--- a/src/main/kotlin/no/josefus/abuhint/dto/ChatMessageModels.kt
+++ b/src/main/kotlin/no/josefus/abuhint/dto/ChatMessageModels.kt
@@ -56,6 +56,48 @@ data class TokenUsageResponse(
     val modelName: String,
 )
 
+@Schema(description = "Tokenforbruk for én aggregert dimensjon")
+data class TokenUsageBreakdownResponse(
+    @field:Schema(description = "Samtale-ID")
+    val chatId: String,
+    @field:Schema(description = "Assistent/persona")
+    val assistant: String,
+    @field:Schema(description = "Klientplattform, f.eks. web, android eller ios")
+    val clientPlatform: String,
+    @field:Schema(description = "Modellnavn")
+    val modelName: String,
+    @field:Schema(description = "Totalt antall input-tokens")
+    val inputTokens: Long,
+    @field:Schema(description = "Antall cached input-tokens")
+    val cachedInputTokens: Long,
+    @field:Schema(description = "Totalt antall output-tokens")
+    val outputTokens: Long,
+    @field:Schema(description = "Sum av input + output tokens")
+    val totalTokens: Long,
+    @field:Schema(description = "Antall API-kall")
+    val requestCount: Int,
+    @field:Schema(description = "Sist oppdatert tidspunkt")
+    val updatedAt: String,
+)
+
+@Schema(description = "Tokenforbruk for innlogget bruker")
+data class TokenUsageSummaryResponse(
+    @field:Schema(description = "Innlogget bruker-ID")
+    val userId: String,
+    @field:Schema(description = "Totalt antall input-tokens")
+    val inputTokens: Long,
+    @field:Schema(description = "Antall cached input-tokens")
+    val cachedInputTokens: Long,
+    @field:Schema(description = "Totalt antall output-tokens")
+    val outputTokens: Long,
+    @field:Schema(description = "Sum av input + output tokens")
+    val totalTokens: Long,
+    @field:Schema(description = "Antall API-kall")
+    val requestCount: Int,
+    @field:Schema(description = "Breakdown per chat, assistant, platform og modell")
+    val breakdown: List<TokenUsageBreakdownResponse>,
+)
+
 @Schema(description = "Informasjon om et enkelt AI-verktøy")
 data class ToolInfo(
     @field:Schema(description = "Verktøyets unike navn", example = "searchWeb")

--- a/src/main/kotlin/no/josefus/abuhint/familie/FamilieChatService.kt
+++ b/src/main/kotlin/no/josefus/abuhint/familie/FamilieChatService.kt
@@ -3,6 +3,8 @@ package no.josefus.abuhint.familie
 import dev.langchain4j.data.message.ChatMessage
 import no.josefus.abuhint.repository.ConcretePineconeChatMemoryStore
 import no.josefus.abuhint.service.ChatIdContextHolder
+import no.josefus.abuhint.service.TokenUsageContext
+import no.josefus.abuhint.service.TokenUsageContextHolder
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -26,10 +28,17 @@ class FamilieChatService(
 
     private val log = LoggerFactory.getLogger(FamilieChatService::class.java)
 
-    fun processChat(chatId: String, userMessage: String, userId: String, metadata: FamilieClientMetadata?): String {
+    fun processChat(
+        chatId: String,
+        userMessage: String,
+        userId: String,
+        metadata: FamilieClientMetadata?,
+        usageContext: TokenUsageContext,
+    ): String {
         val dateTime = buildDateTimeContext(metadata)
         FamilieUserChatRegistry.bind(chatId, userId)
         ChatIdContextHolder.set(chatId)
+        TokenUsageContextHolder.set(usageContext.copy(chatId = chatId, userId = userId))
         return try {
             assistant.chat(chatId, userMessage, dateTime)
         } catch (e: Exception) {
@@ -38,6 +47,7 @@ class FamilieChatService(
         } finally {
             FamilieUserChatRegistry.unbind(chatId)
             ChatIdContextHolder.clear()
+            TokenUsageContextHolder.clear()
         }
     }
 
@@ -46,18 +56,21 @@ class FamilieChatService(
         userMessage: String,
         userId: String,
         metadata: FamilieClientMetadata?,
+        usageContext: TokenUsageContext,
     ): SseEmitter {
         val emitter = SseEmitter(120_000L)
         val dateTime = buildDateTimeContext(metadata)
 
         FamilieUserChatRegistry.bind(chatId, userId)
         ChatIdContextHolder.set(chatId)
+        TokenUsageContextHolder.set(usageContext.copy(chatId = chatId, userId = userId))
         val cleanedUp = AtomicBoolean(false)
 
         fun cleanup() {
             if (!cleanedUp.compareAndSet(false, true)) return
             FamilieUserChatRegistry.unbind(chatId)
             ChatIdContextHolder.clear()
+            TokenUsageContextHolder.clear()
         }
 
         val tokenStream = try {

--- a/src/main/kotlin/no/josefus/abuhint/familie/FamilieController.kt
+++ b/src/main/kotlin/no/josefus/abuhint/familie/FamilieController.kt
@@ -11,7 +11,9 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import no.josefus.abuhint.dto.ChatHistoryMessage
 import no.josefus.abuhint.dto.ChatHistoryResponse
 import no.josefus.abuhint.dto.OpenAiCompatibleContentItem
+import no.josefus.abuhint.controller.ChatController
 import no.josefus.abuhint.service.ChatMessageUtils
+import no.josefus.abuhint.service.TokenUsageContext
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -61,13 +64,20 @@ class FamilieController(
     @PostMapping(value = ["/send"], produces = [MediaType.APPLICATION_JSON_VALUE])
     fun sendMessage(
         @RequestParam(required = false) chatId: String?,
+        @RequestHeader(value = ChatController.CLIENT_PLATFORM_HEADER, required = false) clientPlatform: String? = null,
         @RequestBody request: FamilieMessageRequest,
     ): ResponseEntity<List<OpenAiCompatibleContentItem>> {
         val preconditionError = requireGoogleConnected()
         if (preconditionError != null) return preconditionError
         val sessionId = chatId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
         val userId = currentUserId()
-        val reply = chatService.processChat(sessionId, request.message, userId, request.metadata)
+        val reply = chatService.processChat(
+            sessionId,
+            request.message,
+            userId,
+            request.metadata,
+            usageContext(userId, sessionId, clientPlatform),
+        )
         return ResponseEntity.ok(listOf(OpenAiCompatibleContentItem(type = "text", text = reply)))
     }
 
@@ -78,13 +88,20 @@ class FamilieController(
     @PostMapping(value = ["/stream"], produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
     fun streamMessage(
         @RequestParam(required = false) chatId: String?,
+        @RequestHeader(value = ChatController.CLIENT_PLATFORM_HEADER, required = false) clientPlatform: String? = null,
         @RequestBody request: FamilieMessageRequest,
     ): Any {
         val preconditionError = requireGoogleConnected()
         if (preconditionError != null) return preconditionError
         val sessionId = chatId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
         val userId = currentUserId()
-        return chatService.processChatStream(sessionId, request.message, userId, request.metadata)
+        return chatService.processChatStream(
+            sessionId,
+            request.message,
+            userId,
+            request.metadata,
+            usageContext(userId, sessionId, clientPlatform),
+        )
     }
 
     @Operation(summary = "Hent samtalehistorikk for Familieplanleggern")
@@ -118,6 +135,13 @@ class FamilieController(
     private fun currentUserId(): String =
         SecurityContextHolder.getContext().authentication?.name
             ?: throw IllegalStateException("No authenticated user in SecurityContext")
+
+    private fun usageContext(userId: String, chatId: String, clientPlatform: String?) = TokenUsageContext(
+        userId = userId,
+        chatId = chatId,
+        assistant = "FAMILIE",
+        clientPlatform = clientPlatform?.trim()?.takeIf { it.isNotBlank() } ?: "unknown",
+    )
 
     /**
      * Guard: the Familieplanleggern chat endpoints are useless without a Google connection,

--- a/src/main/kotlin/no/josefus/abuhint/service/ChatService.kt
+++ b/src/main/kotlin/no/josefus/abuhint/service/ChatService.kt
@@ -7,7 +7,6 @@ import dev.langchain4j.data.message.UserMessage
 import dev.langchain4j.data.segment.TextSegment
 import dev.langchain4j.service.TokenStream
 import dev.langchain4j.store.embedding.EmbeddingMatch
-import no.josefus.abuhint.service.Tokenizer
 import java.util.UUID
 import no.josefus.abuhint.repository.ConcretePineconeChatMemoryStore
 import no.josefus.abuhint.repository.LangChain4jAssistant
@@ -15,6 +14,7 @@ import no.josefus.abuhint.repository.TechAdvisorAssistant
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.util.concurrent.atomic.AtomicBoolean
 
 @Service
 class ChatService(
@@ -52,16 +52,16 @@ class ChatService(
         throw lastException!!
     }
 
-    fun processChat(chatId: String, userMessage: String): String {
+    fun processChat(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): String {
         val dateTime = java.time.LocalDateTime.now().toString()
-        return processChatInternal(chatId, userMessage, openAiTokenizer, "openai") { effectiveChatId, message, uuid ->
+        return processChatInternal(chatId, userMessage, openAiTokenizer, "openai", usageContext) { effectiveChatId, message, uuid ->
             retryLlmCall { assistant.chat(effectiveChatId, message, uuid, dateTime) }
         }
     }
 
-    fun processGeminiChat(chatId: String, userMessage: String): String {
+    fun processGeminiChat(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): String {
         val dateTime = java.time.LocalDateTime.now().toString()
-        return processChatInternal(chatId, userMessage, geminiTokenizer, "gemini") { effectiveChatId, message, uuid ->
+        return processChatInternal(chatId, userMessage, geminiTokenizer, "gemini", usageContext) { effectiveChatId, message, uuid ->
             retryLlmCall { geminiAssistant.chat(effectiveChatId, message, uuid, dateTime) }
         }
     }
@@ -71,6 +71,7 @@ class ChatService(
         userMessage: String,
         tokenizer: Tokenizer,
         modelLabel: String,
+        usageContext: TokenUsageContext?,
         chatFn: (String, String, String) -> String
     ): String {
         val uuid = UUID.randomUUID().toString()
@@ -109,11 +110,16 @@ class ChatService(
         }
 
         val modelStart = System.nanoTime()
+        val effectiveUsageContext = usageContext?.copy(chatId = effectiveChatId)
         ChatIdContextHolder.set(effectiveChatId)
+        if (effectiveUsageContext != null) {
+            TokenUsageContextHolder.set(effectiveUsageContext)
+        }
         val response = try {
             chatFn(effectiveChatId, finalMessage, uuid)
         } finally {
             ChatIdContextHolder.clear()
+            TokenUsageContextHolder.clear()
         }
         val modelMs = (System.nanoTime() - modelStart) / 1_000_000
         log.info("LatMeasure: modelMs={} ({})", modelMs, modelLabel)
@@ -257,15 +263,15 @@ class ChatService(
         return concretePineconeChatMemoryStore.retrieveFromPineconeWithTokenLimit(memoryId, query, maxTokens, tokenizer)
     }
 
-    fun processChatStream(chatId: String, userMessage: String): SseEmitter {
-        return streamFromAssistant(chatId, userMessage, openAiTokenizer) { effectiveChatId, enhancedMessage, uuid ->
+    fun processChatStream(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): SseEmitter {
+        return streamFromAssistant(chatId, userMessage, openAiTokenizer, usageContext) { effectiveChatId, enhancedMessage, uuid ->
             val dateTime = java.time.LocalDateTime.now().toString()
             assistant.chatStream(effectiveChatId, enhancedMessage, uuid)
         }
     }
 
-    fun processGeminiChatStream(chatId: String, userMessage: String): SseEmitter {
-        return streamFromAssistant(chatId, userMessage, geminiTokenizer) { effectiveChatId, enhancedMessage, uuid ->
+    fun processGeminiChatStream(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): SseEmitter {
+        return streamFromAssistant(chatId, userMessage, geminiTokenizer, usageContext) { effectiveChatId, enhancedMessage, uuid ->
             val dateTime = java.time.LocalDateTime.now().toString()
             geminiAssistant.chatStream(effectiveChatId, enhancedMessage, uuid, dateTime)
         }
@@ -275,6 +281,7 @@ class ChatService(
         chatId: String,
         userMessage: String,
         tokenizer: Tokenizer,
+        usageContext: TokenUsageContext?,
         streamFactory: (String, String, String) -> TokenStream
     ): SseEmitter {
         val emitter = SseEmitter(120_000L)
@@ -298,11 +305,24 @@ class ChatService(
             "$enhancedMessage\nUser: $userMessage"
         }
 
+        val effectiveUsageContext = usageContext?.copy(chatId = effectiveChatId)
+        val cleanedUp = AtomicBoolean(false)
+
+        fun cleanup() {
+            if (!cleanedUp.compareAndSet(false, true)) return
+            ChatIdContextHolder.clear()
+            TokenUsageContextHolder.clear()
+        }
+
         ChatIdContextHolder.set(effectiveChatId)
+        if (effectiveUsageContext != null) {
+            TokenUsageContextHolder.set(effectiveUsageContext)
+        }
         val tokenStream = try {
             streamFactory(effectiveChatId, finalMessage, uuid)
-        } finally {
-            ChatIdContextHolder.clear()
+        } catch (e: Exception) {
+            cleanup()
+            throw e
         }
         val fullResponse = StringBuilder()
 
@@ -321,6 +341,8 @@ class ChatService(
                     emitter.complete()
                 } catch (e: Exception) {
                     log.debug("Error completing SSE stream: ${e.message}")
+                } finally {
+                    cleanup()
                 }
             }
             .onError { error ->
@@ -330,12 +352,26 @@ class ChatService(
                     emitter.completeWithError(error)
                 } catch (e: Exception) {
                     log.debug("Error sending error event: ${e.message}")
+                } finally {
+                    cleanup()
                 }
             }
-            .start()
+        try {
+            tokenStream.start()
+        } catch (e: Exception) {
+            cleanup()
+            throw e
+        }
 
-        emitter.onTimeout { log.warn("SSE stream timed out for chatId=$effectiveChatId") }
-        emitter.onError { log.debug("SSE emitter error for chatId=$effectiveChatId: ${it.message}") }
+        emitter.onCompletion { cleanup() }
+        emitter.onTimeout {
+            log.warn("SSE stream timed out for chatId=$effectiveChatId")
+            cleanup()
+        }
+        emitter.onError {
+            log.debug("SSE emitter error for chatId=$effectiveChatId: ${it.message}")
+            cleanup()
+        }
 
         return emitter
     }

--- a/src/main/kotlin/no/josefus/abuhint/service/OpenAiCompatibleService.kt
+++ b/src/main/kotlin/no/josefus/abuhint/service/OpenAiCompatibleService.kt
@@ -5,6 +5,15 @@ import no.josefus.abuhint.dto.OpenAiCompatibleChatCompletionResponse
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 
 interface OpenAiCompatibleService {
-    fun createChatCompletion(request: OpenAiCompatibleChatCompletionRequest): OpenAiCompatibleChatCompletionResponse
-    fun createStreamingChatCompletion(request: OpenAiCompatibleChatCompletionRequest): SseEmitter
+    fun createChatCompletion(
+        request: OpenAiCompatibleChatCompletionRequest,
+        userId: String,
+        clientPlatform: String,
+    ): OpenAiCompatibleChatCompletionResponse
+
+    fun createStreamingChatCompletion(
+        request: OpenAiCompatibleChatCompletionRequest,
+        userId: String,
+        clientPlatform: String,
+    ): SseEmitter
 }

--- a/src/main/kotlin/no/josefus/abuhint/service/OpenAiCompatibleServiceImpl.kt
+++ b/src/main/kotlin/no/josefus/abuhint/service/OpenAiCompatibleServiceImpl.kt
@@ -5,6 +5,7 @@ import no.josefus.abuhint.dto.OpenAiCompatibleChatCompletionResponse
 import no.josefus.abuhint.dto.OpenAiCompatibleChatMessage
 import no.josefus.abuhint.dto.OpenAiCompatibleChoice
 import no.josefus.abuhint.dto.OpenAiCompatibleContentItem
+import no.josefus.abuhint.dto.OpenAiCompatibleUsage
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -13,8 +14,13 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 class OpenAiCompatibleServiceImpl(
     private val chatService: ChatService,
     @Value("\${langchain4j.open-ai.chat-model.model-name}") private val modelName: String,
+    private val tokenUsageStore: TokenUsageStore,
 ) : OpenAiCompatibleService {
-    override fun createChatCompletion(request: OpenAiCompatibleChatCompletionRequest): OpenAiCompatibleChatCompletionResponse {
+    override fun createChatCompletion(
+        request: OpenAiCompatibleChatCompletionRequest,
+        userId: String,
+        clientPlatform: String,
+    ): OpenAiCompatibleChatCompletionResponse {
         if (request.messages.isEmpty()) {
             throw IllegalArgumentException("Messages cannot be empty")
         }
@@ -27,7 +33,18 @@ class OpenAiCompatibleServiceImpl(
             ?: throw IllegalArgumentException("No user message found in request")
 
         val chatId = request.chatId?.takeIf { it.isNotBlank() } ?: "openai-${System.currentTimeMillis()}"
-        val reply = chatService.processChat(chatId, userMessage)
+        val beforeUsage = tokenUsageStore.getUsageForUserChat(userId, chatId)
+        val reply = chatService.processChat(
+            chatId,
+            userMessage,
+            TokenUsageContext(
+                userId = userId,
+                chatId = chatId,
+                assistant = "OPENAI_COMPATIBLE",
+                clientPlatform = clientPlatform,
+            ),
+        )
+        val usage = usageDelta(beforeUsage, tokenUsageStore.getUsageForUserChat(userId, chatId))
 
         val responseMessage = OpenAiCompatibleChatMessage(
             role = "assistant",
@@ -43,18 +60,45 @@ class OpenAiCompatibleServiceImpl(
             created = System.currentTimeMillis() / 1000,
             model = modelName,
             choices = listOf(choice),
-            usage = null // You can fill this if you want token usage stats
+            usage = usage,
         )
     }
 
-    override fun createStreamingChatCompletion(request: OpenAiCompatibleChatCompletionRequest): SseEmitter {
+    override fun createStreamingChatCompletion(
+        request: OpenAiCompatibleChatCompletionRequest,
+        userId: String,
+        clientPlatform: String,
+    ): SseEmitter {
         if (request.messages.isEmpty()) {
             throw IllegalArgumentException("Messages cannot be empty")
         }
         val userMessage = request.messages.lastOrNull { it.role == "user" }?.content?.joinToString("\n") { it.text ?: "" }
             ?: throw IllegalArgumentException("No user message found in request")
         val chatId = request.chatId?.takeIf { it.isNotBlank() } ?: "openai-${System.currentTimeMillis()}"
-        return chatService.processChatStream(chatId, userMessage)
+        return chatService.processChatStream(
+            chatId,
+            userMessage,
+            TokenUsageContext(
+                userId = userId,
+                chatId = chatId,
+                assistant = "OPENAI_COMPATIBLE",
+                clientPlatform = clientPlatform,
+            ),
+        )
     }
+
+    private fun usageDelta(before: TokenUsageSummary, after: TokenUsageSummary): OpenAiCompatibleUsage? {
+        val promptTokens = (after.inputTokens - before.inputTokens).coerceAtLeast(0)
+        val completionTokens = (after.outputTokens - before.outputTokens).coerceAtLeast(0)
+        val totalTokens = promptTokens + completionTokens
+        if (totalTokens == 0L) return null
+        return OpenAiCompatibleUsage(
+            promptTokens = promptTokens.toSafeInt(),
+            completionTokens = completionTokens.toSafeInt(),
+            totalTokens = totalTokens.toSafeInt(),
+        )
+    }
+
+    private fun Long.toSafeInt(): Int = coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
 }
 

--- a/src/main/kotlin/no/josefus/abuhint/service/TokenUsageAggregateEntity.kt
+++ b/src/main/kotlin/no/josefus/abuhint/service/TokenUsageAggregateEntity.kt
@@ -1,0 +1,64 @@
+package no.josefus.abuhint.service
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.time.Instant
+
+@Entity
+@Table(
+    name = "token_usage_aggregate",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uq_token_usage_aggregate",
+            columnNames = ["user_id", "chat_id", "assistant", "client_platform", "model_name"],
+        ),
+    ],
+    indexes = [
+        Index(name = "idx_token_usage_aggregate_user_updated", columnList = "user_id, updated_at"),
+    ],
+)
+class TokenUsageAggregateEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    var id: Long? = null,
+
+    @Column(name = "user_id", length = 128, nullable = false)
+    var userId: String = "",
+
+    @Column(name = "chat_id", length = 128, nullable = false)
+    var chatId: String = "",
+
+    @Column(name = "assistant", length = 64, nullable = false)
+    var assistant: String = "",
+
+    @Column(name = "client_platform", length = 64, nullable = false)
+    var clientPlatform: String = "",
+
+    @Column(name = "model_name", length = 128, nullable = false)
+    var modelName: String = "",
+
+    @Column(name = "input_tokens", nullable = false)
+    var inputTokens: Long = 0,
+
+    @Column(name = "cached_input_tokens", nullable = false)
+    var cachedInputTokens: Long = 0,
+
+    @Column(name = "output_tokens", nullable = false)
+    var outputTokens: Long = 0,
+
+    @Column(name = "request_count", nullable = false)
+    var requestCount: Int = 0,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: Instant = Instant.EPOCH,
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant = Instant.EPOCH,
+)

--- a/src/main/kotlin/no/josefus/abuhint/service/TokenUsageAggregateRepository.kt
+++ b/src/main/kotlin/no/josefus/abuhint/service/TokenUsageAggregateRepository.kt
@@ -1,0 +1,22 @@
+package no.josefus.abuhint.service
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TokenUsageAggregateRepository : JpaRepository<TokenUsageAggregateEntity, Long> {
+    fun findByUserIdAndChatIdAndAssistantAndClientPlatformAndModelName(
+        userId: String,
+        chatId: String,
+        assistant: String,
+        clientPlatform: String,
+        modelName: String,
+    ): TokenUsageAggregateEntity?
+
+    fun findAllByUserIdOrderByUpdatedAtDesc(userId: String): List<TokenUsageAggregateEntity>
+
+    fun findAllByUserIdAndChatIdOrderByUpdatedAtDesc(
+        userId: String,
+        chatId: String,
+    ): List<TokenUsageAggregateEntity>
+}

--- a/src/main/kotlin/no/josefus/abuhint/service/TokenUsageContextHolder.kt
+++ b/src/main/kotlin/no/josefus/abuhint/service/TokenUsageContextHolder.kt
@@ -1,0 +1,9 @@
+package no.josefus.abuhint.service
+
+object TokenUsageContextHolder {
+    private val holder = ThreadLocal<TokenUsageContext>()
+
+    fun set(context: TokenUsageContext) = holder.set(context)
+    fun get(): TokenUsageContext? = holder.get()
+    fun clear() = holder.remove()
+}

--- a/src/main/kotlin/no/josefus/abuhint/service/TokenUsageStore.kt
+++ b/src/main/kotlin/no/josefus/abuhint/service/TokenUsageStore.kt
@@ -1,16 +1,21 @@
 package no.josefus.abuhint.service
 
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
 
 @Service
-class TokenUsageStore {
+class TokenUsageStore(
+    private val repository: TokenUsageAggregateRepository,
+) {
 
     private val usageMap = ConcurrentHashMap<String, TokenUsageRecord>()
 
     fun record(chatId: String, entry: TokenUsageEntry) {
+        if (!entry.hasAnyTokens()) return
         usageMap.compute(chatId) { _, existing ->
             (existing ?: TokenUsageRecord(chatId = chatId)).apply {
                 inputTokens.addAndGet(entry.inputTokens.toLong())
@@ -22,9 +27,73 @@ class TokenUsageStore {
         }
     }
 
+    @Transactional
+    fun record(context: TokenUsageContext, entry: TokenUsageEntry) {
+        if (!entry.hasAnyTokens()) return
+        record(context.chatId, entry)
+
+        val normalized = context.normalized()
+        val now = Instant.now()
+        val entity = repository.findByUserIdAndChatIdAndAssistantAndClientPlatformAndModelName(
+            userId = normalized.userId,
+            chatId = normalized.chatId,
+            assistant = normalized.assistant,
+            clientPlatform = normalized.clientPlatform,
+            modelName = entry.modelName.normalizedValue("unknown", 128),
+        ) ?: TokenUsageAggregateEntity(
+            userId = normalized.userId,
+            chatId = normalized.chatId,
+            assistant = normalized.assistant,
+            clientPlatform = normalized.clientPlatform,
+            modelName = entry.modelName.normalizedValue("unknown", 128),
+            createdAt = now,
+        )
+
+        entity.inputTokens += entry.inputTokens.toLong()
+        entity.cachedInputTokens += entry.cachedInputTokens.toLong()
+        entity.outputTokens += entry.outputTokens.toLong()
+        entity.requestCount += 1
+        entity.updatedAt = now
+        repository.save(entity)
+    }
+
     fun getUsage(chatId: String): TokenUsageRecord? = usageMap[chatId]
 
     fun getAllUsage(): Map<String, TokenUsageRecord> = usageMap.toMap()
+
+    @Transactional(readOnly = true)
+    fun getUsageForUser(userId: String): TokenUsageSummary =
+        repository.findAllByUserIdOrderByUpdatedAtDesc(userId)
+            .toSummary(userId)
+
+    @Transactional(readOnly = true)
+    fun getUsageForUserChat(userId: String, chatId: String): TokenUsageSummary =
+        repository.findAllByUserIdAndChatIdOrderByUpdatedAtDesc(userId, chatId)
+            .toSummary(userId)
+
+    private fun List<TokenUsageAggregateEntity>.toSummary(userId: String): TokenUsageSummary {
+        val rows = map { it.toBreakdown() }
+        return TokenUsageSummary(
+            userId = userId,
+            inputTokens = rows.sumOf { it.inputTokens },
+            cachedInputTokens = rows.sumOf { it.cachedInputTokens },
+            outputTokens = rows.sumOf { it.outputTokens },
+            requestCount = rows.sumOf { it.requestCount },
+            breakdown = rows,
+        )
+    }
+
+    private fun TokenUsageAggregateEntity.toBreakdown() = TokenUsageBreakdown(
+        chatId = chatId,
+        assistant = assistant,
+        clientPlatform = clientPlatform,
+        modelName = modelName,
+        inputTokens = inputTokens,
+        cachedInputTokens = cachedInputTokens,
+        outputTokens = outputTokens,
+        requestCount = requestCount,
+        updatedAt = updatedAt,
+    )
 }
 
 data class TokenUsageEntry(
@@ -32,7 +101,48 @@ data class TokenUsageEntry(
     val cachedInputTokens: Int,
     val outputTokens: Int,
     val modelName: String,
-)
+) {
+    fun hasAnyTokens(): Boolean = inputTokens != 0 || cachedInputTokens != 0 || outputTokens != 0
+}
+
+data class TokenUsageContext(
+    val userId: String,
+    val chatId: String,
+    val assistant: String,
+    val clientPlatform: String,
+) {
+    fun normalized(): TokenUsageContext = copy(
+        userId = userId.normalizedValue("unknown-user", 128),
+        chatId = chatId.normalizedValue("unknown-chat", 128),
+        assistant = assistant.normalizedValue("UNKNOWN", 64).uppercase(),
+        clientPlatform = clientPlatform.normalizedValue("unknown", 64).lowercase(),
+    )
+}
+
+data class TokenUsageSummary(
+    val userId: String,
+    val inputTokens: Long,
+    val cachedInputTokens: Long,
+    val outputTokens: Long,
+    val requestCount: Int,
+    val breakdown: List<TokenUsageBreakdown>,
+) {
+    val totalTokens: Long = inputTokens + outputTokens
+}
+
+data class TokenUsageBreakdown(
+    val chatId: String,
+    val assistant: String,
+    val clientPlatform: String,
+    val modelName: String,
+    val inputTokens: Long,
+    val cachedInputTokens: Long,
+    val outputTokens: Long,
+    val requestCount: Int,
+    val updatedAt: Instant,
+) {
+    val totalTokens: Long = inputTokens + outputTokens
+}
 
 class TokenUsageRecord(
     val chatId: String,
@@ -42,3 +152,6 @@ class TokenUsageRecord(
     val requestCount: AtomicInteger = AtomicInteger(0),
     @Volatile var lastModelName: String = "",
 )
+
+private fun String.normalizedValue(defaultValue: String, maxLength: Int): String =
+    trim().takeIf { it.isNotBlank() }?.take(maxLength) ?: defaultValue

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   jwt:
     secret: ${JOSEFUS_JWT_SECRET}
   datasource:
-    url: ${DATASOURCE_URL:jdbc:h2:mem:abuhint;DB_CLOSE_DELAY=-1;MODE=PostgreSQL}
+    url: ${DATASOURCE_URL:jdbc:h2:mem:abuhint;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;INIT=CREATE DOMAIN IF NOT EXISTS TIMESTAMPTZ AS TIMESTAMP WITH TIME ZONE}
     username: ${DATASOURCE_USERNAME:sa}
     password: ${DATASOURCE_PASSWORD:}
     driver-class-name: ${DATASOURCE_DRIVER:org.h2.Driver}

--- a/src/main/resources/db/migration/V2__create_token_usage_aggregate.sql
+++ b/src/main/resources/db/migration/V2__create_token_usage_aggregate.sql
@@ -1,0 +1,19 @@
+CREATE TABLE token_usage_aggregate (
+    id                  BIGSERIAL     NOT NULL,
+    user_id             VARCHAR(128)  NOT NULL,
+    chat_id             VARCHAR(128)  NOT NULL,
+    assistant           VARCHAR(64)   NOT NULL,
+    client_platform     VARCHAR(64)   NOT NULL,
+    model_name          VARCHAR(128)  NOT NULL,
+    input_tokens        BIGINT        NOT NULL DEFAULT 0,
+    cached_input_tokens BIGINT        NOT NULL DEFAULT 0,
+    output_tokens       BIGINT        NOT NULL DEFAULT 0,
+    request_count       INTEGER       NOT NULL DEFAULT 0,
+    created_at          TIMESTAMPTZ   NOT NULL,
+    updated_at          TIMESTAMPTZ   NOT NULL,
+    CONSTRAINT pk_token_usage_aggregate PRIMARY KEY (id),
+    CONSTRAINT uq_token_usage_aggregate UNIQUE (user_id, chat_id, assistant, client_platform, model_name)
+);
+
+CREATE INDEX idx_token_usage_aggregate_user_updated
+    ON token_usage_aggregate (user_id, updated_at);

--- a/src/test/kotlin/no/josefus/abuhint/controller/ChatControllerUsageContextTest.kt
+++ b/src/test/kotlin/no/josefus/abuhint/controller/ChatControllerUsageContextTest.kt
@@ -1,0 +1,88 @@
+package no.josefus.abuhint.controller
+
+import no.josefus.abuhint.service.ChatService
+import no.josefus.abuhint.service.TokenUsageBreakdown
+import no.josefus.abuhint.service.TokenUsageContext
+import no.josefus.abuhint.service.TokenUsageSummary
+import no.josefus.abuhint.service.TokenUsageStore
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import java.time.Instant
+import kotlin.test.assertEquals
+
+class ChatControllerUsageContextTest {
+
+    private val chatService: ChatService = mock()
+    private val tokenUsageStore: TokenUsageStore = mock()
+    private val controller = ChatController(chatService, tokenUsageStore)
+
+    @BeforeEach
+    fun auth() {
+        SecurityContextHolder.getContext().authentication =
+            UsernamePasswordAuthenticationToken("user-42", null, emptyList())
+    }
+
+    @Test
+    fun `send passes current user platform and abuhint assistant to chat service`() {
+        whenever(chatService.processChat(any(), any(), any<TokenUsageContext>())).thenReturn("Hei!")
+
+        val response = controller.sendMessage(
+            chatId = "chat-1",
+            credentials = null,
+            clientPlatform = "android",
+            message = ChatController.MessageRequest("hei"),
+        )
+
+        assertEquals(200, response.statusCode.value())
+        verify(chatService).processChat(
+            "chat-1",
+            "hei",
+            TokenUsageContext(
+                userId = "user-42",
+                chatId = "chat-1",
+                assistant = "ABUHINT",
+                clientPlatform = "android",
+            ),
+        )
+    }
+
+    @Test
+    fun `usage endpoint returns current user summary from persistent store`() {
+        whenever(tokenUsageStore.getUsageForUser("user-42")).thenReturn(
+            TokenUsageSummary(
+                userId = "user-42",
+                inputTokens = 10,
+                cachedInputTokens = 2,
+                outputTokens = 5,
+                requestCount = 1,
+                breakdown = listOf(
+                    TokenUsageBreakdown(
+                        chatId = "chat-1",
+                        assistant = "ABUHINT",
+                        clientPlatform = "android",
+                        modelName = "gpt-5.4-mini",
+                        inputTokens = 10,
+                        cachedInputTokens = 2,
+                        outputTokens = 5,
+                        requestCount = 1,
+                        updatedAt = Instant.parse("2026-05-01T00:00:00Z"),
+                    ),
+                ),
+            )
+        )
+
+        val response = controller.getAllTokenUsage()
+
+        assertEquals(200, response.statusCode.value())
+        assertEquals("user-42", response.body!!.userId)
+        assertEquals(15, response.body!!.totalTokens)
+        assertEquals("ABUHINT", response.body!!.breakdown.single().assistant)
+        verify(tokenUsageStore).getUsageForUser("user-42")
+    }
+}

--- a/src/test/kotlin/no/josefus/abuhint/familie/FamilieControllerPreconditionTest.kt
+++ b/src/test/kotlin/no/josefus/abuhint/familie/FamilieControllerPreconditionTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
+import no.josefus.abuhint.service.TokenUsageContext
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -37,7 +38,7 @@ class FamilieControllerPreconditionTest {
         assertEquals(412, response.statusCode.value())
         val text = response.body!!.first().text
         assertTrue(text!!.contains("Google", ignoreCase = true))
-        verify(chatService, never()).processChat(any(), any(), any(), anyOrNull())
+        verify(chatService, never()).processChat(any(), any(), any(), anyOrNull(), any())
     }
 
     @Test
@@ -45,15 +46,27 @@ class FamilieControllerPreconditionTest {
         whenever(credentialStore.load("user-42")).thenReturn(
             GoogleCredentials("user-42", "rt", "at", null, "scope", "e@x", "UTC")
         )
-        whenever(chatService.processChat(any(), any(), any(), anyOrNull())).thenReturn("Klart!")
+        whenever(chatService.processChat(any(), any(), any(), anyOrNull(), any())).thenReturn("Klart!")
 
         val response = controller.sendMessage(
             chatId = "chat-1",
+            clientPlatform = "ios",
             request = FamilieMessageRequest("hei"),
         )
 
         assertEquals(200, response.statusCode.value())
         assertEquals("Klart!", response.body!!.first().text)
-        verify(chatService).processChat("chat-1", "hei", "user-42", null)
+        verify(chatService).processChat(
+            "chat-1",
+            "hei",
+            "user-42",
+            null,
+            TokenUsageContext(
+                userId = "user-42",
+                chatId = "chat-1",
+                assistant = "FAMILIE",
+                clientPlatform = "ios",
+            ),
+        )
     }
 }

--- a/src/test/kotlin/no/josefus/abuhint/familie/JpaUserGoogleCredentialStoreTest.kt
+++ b/src/test/kotlin/no/josefus/abuhint/familie/JpaUserGoogleCredentialStoreTest.kt
@@ -3,10 +3,12 @@ package no.josefus.abuhint.familie
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Import
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.test.context.TestPropertySource
 import java.time.Instant
 import java.util.Base64
 import kotlin.test.assertEquals
@@ -15,7 +17,16 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import(JpaUserGoogleCredentialStoreTest.Config::class)
+@TestPropertySource(
+    properties = [
+        "spring.datasource.url=jdbc:h2:mem:google_credential_test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;INIT=CREATE DOMAIN IF NOT EXISTS TIMESTAMPTZ AS TIMESTAMP WITH TIME ZONE",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+    ],
+)
 class JpaUserGoogleCredentialStoreTest {
 
     @Autowired

--- a/src/test/kotlin/no/josefus/abuhint/service/OpenAiCompatibleServiceImplTest.kt
+++ b/src/test/kotlin/no/josefus/abuhint/service/OpenAiCompatibleServiceImplTest.kt
@@ -1,0 +1,71 @@
+package no.josefus.abuhint.service
+
+import no.josefus.abuhint.dto.OpenAiCompatibleChatCompletionRequest
+import no.josefus.abuhint.dto.OpenAiCompatibleChatMessage
+import no.josefus.abuhint.dto.OpenAiCompatibleContentItem
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.test.assertEquals
+
+class OpenAiCompatibleServiceImplTest {
+
+    private val chatService: ChatService = mock()
+    private val tokenUsageStore: TokenUsageStore = mock()
+    private val service = OpenAiCompatibleServiceImpl(chatService, "gpt-5.4-mini", tokenUsageStore)
+
+    @Test
+    fun `non streaming response includes token usage delta for request`() {
+        val request = OpenAiCompatibleChatCompletionRequest(
+            messages = listOf(
+                OpenAiCompatibleChatMessage(
+                    role = "user",
+                    content = listOf(OpenAiCompatibleContentItem(type = "text", text = "hei")),
+                )
+            ),
+            chatId = "chat-1",
+        )
+        whenever(tokenUsageStore.getUsageForUserChat("user-42", "chat-1"))
+            .thenReturn(emptySummary("user-42"))
+            .thenReturn(
+                TokenUsageSummary(
+                    userId = "user-42",
+                    inputTokens = 10,
+                    cachedInputTokens = 0,
+                    outputTokens = 5,
+                    requestCount = 1,
+                    breakdown = emptyList(),
+                )
+            )
+        whenever(chatService.processChat(eq("chat-1"), eq("hei"), any<TokenUsageContext>())).thenReturn("svar")
+
+        val response = service.createChatCompletion(request, userId = "user-42", clientPlatform = "web")
+        val usage = response.usage!!
+
+        assertEquals(10, usage.promptTokens)
+        assertEquals(5, usage.completionTokens)
+        assertEquals(15, usage.totalTokens)
+        verify(chatService).processChat(
+            "chat-1",
+            "hei",
+            TokenUsageContext(
+                userId = "user-42",
+                chatId = "chat-1",
+                assistant = "OPENAI_COMPATIBLE",
+                clientPlatform = "web",
+            ),
+        )
+    }
+
+    private fun emptySummary(userId: String) = TokenUsageSummary(
+        userId = userId,
+        inputTokens = 0,
+        cachedInputTokens = 0,
+        outputTokens = 0,
+        requestCount = 0,
+        breakdown = emptyList(),
+    )
+}

--- a/src/test/kotlin/no/josefus/abuhint/service/TokenUsagePersistenceTest.kt
+++ b/src/test/kotlin/no/josefus/abuhint/service/TokenUsagePersistenceTest.kt
@@ -1,0 +1,156 @@
+package no.josefus.abuhint.service
+
+import dev.langchain4j.data.message.AiMessage
+import dev.langchain4j.data.message.UserMessage
+import dev.langchain4j.model.ModelProvider
+import dev.langchain4j.model.chat.listener.ChatModelRequestContext
+import dev.langchain4j.model.chat.listener.ChatModelResponseContext
+import dev.langchain4j.model.chat.request.ChatRequest
+import dev.langchain4j.model.chat.response.ChatResponse
+import dev.langchain4j.model.output.TokenUsage
+import no.josefus.abuhint.configuration.OpenAiTokenUsageListener
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Import
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories
+import org.springframework.test.context.TestPropertySource
+import kotlin.test.assertEquals
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TokenUsagePersistenceTest.Config::class)
+@TestPropertySource(
+    properties = [
+        "spring.datasource.url=jdbc:h2:mem:token_usage_test;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;INIT=CREATE DOMAIN IF NOT EXISTS TIMESTAMPTZ AS TIMESTAMP WITH TIME ZONE",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+    ],
+)
+class TokenUsagePersistenceTest {
+
+    @Autowired
+    lateinit var repository: TokenUsageAggregateRepository
+
+    private fun store() = TokenUsageStore(repository)
+
+    @Test
+    fun `record accumulates usage for same user chat assistant platform and model`() {
+        val context = TokenUsageContext(
+            userId = "user-1",
+            chatId = "chat-1",
+            assistant = "ABUHINT",
+            clientPlatform = "android",
+        )
+
+        store().record(context, TokenUsageEntry(inputTokens = 10, cachedInputTokens = 2, outputTokens = 5, modelName = "gpt-5.4-mini"))
+        store().record(context, TokenUsageEntry(inputTokens = 4, cachedInputTokens = 1, outputTokens = 6, modelName = "gpt-5.4-mini"))
+
+        val summary = store().getUsageForUser("user-1")
+
+        assertEquals(14, summary.inputTokens)
+        assertEquals(3, summary.cachedInputTokens)
+        assertEquals(11, summary.outputTokens)
+        assertEquals(25, summary.totalTokens)
+        assertEquals(2, summary.requestCount)
+        assertEquals(1, summary.breakdown.size)
+
+        val row = summary.breakdown.single()
+        assertEquals("chat-1", row.chatId)
+        assertEquals("ABUHINT", row.assistant)
+        assertEquals("android", row.clientPlatform)
+        assertEquals("gpt-5.4-mini", row.modelName)
+    }
+
+    @Test
+    fun `usage stays isolated by user`() {
+        store().record(
+            TokenUsageContext("alice", "chat-1", "ABUHINT", "web"),
+            TokenUsageEntry(10, 0, 5, "gpt-5.4-mini"),
+        )
+        store().record(
+            TokenUsageContext("bob", "chat-1", "ABUHINT", "web"),
+            TokenUsageEntry(100, 0, 50, "gpt-5.4-mini"),
+        )
+
+        val alice = store().getUsageForUser("alice")
+
+        assertEquals(15, alice.totalTokens)
+        assertEquals(1, alice.requestCount)
+        assertEquals("alice", alice.userId)
+    }
+
+    @Test
+    fun `zero token usage does not create aggregate row`() {
+        store().record(
+            TokenUsageContext("user-2", "chat-2", "ABUHINT", "ios"),
+            TokenUsageEntry(0, 0, 0, "gpt-5.4-mini"),
+        )
+
+        assertEquals(0, repository.count())
+        assertEquals(0, store().getUsageForUser("user-2").requestCount)
+    }
+
+    @Test
+    fun `chat usage returns only matching chat for current user`() {
+        store().record(
+            TokenUsageContext("user-3", "chat-a", "ABUHINT", "web"),
+            TokenUsageEntry(10, 0, 5, "gpt-5.4-mini"),
+        )
+        store().record(
+            TokenUsageContext("user-3", "chat-b", "FAMILIE", "web"),
+            TokenUsageEntry(20, 0, 10, "gpt-5.4-mini"),
+        )
+
+        val chatUsage = store().getUsageForUserChat("user-3", "chat-b")
+
+        assertEquals(30, chatUsage.totalTokens)
+        assertEquals(1, chatUsage.breakdown.size)
+        assertEquals("FAMILIE", chatUsage.breakdown.single().assistant)
+    }
+
+    @Test
+    fun `listener persists usage with context copied from request to response`() {
+        val context = TokenUsageContext(
+            userId = "user-listener",
+            chatId = "chat-listener",
+            assistant = "ABUHINT",
+            clientPlatform = "android",
+        )
+        val request = ChatRequest.builder()
+            .messages(UserMessage.from("hei"))
+            .build()
+        val attributes = mutableMapOf<Any, Any>()
+        val listener = OpenAiTokenUsageListener(store())
+
+        TokenUsageContextHolder.set(context)
+        try {
+            listener.onRequest(ChatModelRequestContext(request, ModelProvider.OPEN_AI, attributes))
+        } finally {
+            TokenUsageContextHolder.clear()
+        }
+
+        val response = ChatResponse.builder()
+            .aiMessage(AiMessage.from("svar"))
+            .modelName("gpt-5.4-mini")
+            .tokenUsage(TokenUsage(12, 7, 19))
+            .build()
+
+        listener.onResponse(ChatModelResponseContext(response, request, ModelProvider.OPEN_AI, attributes))
+
+        val summary = store().getUsageForUser("user-listener")
+        assertEquals(19, summary.totalTokens)
+        assertEquals(1, summary.requestCount)
+        assertEquals("ABUHINT", summary.breakdown.single().assistant)
+        assertEquals("android", summary.breakdown.single().clientPlatform)
+    }
+
+    @TestConfiguration
+    @EnableJpaRepositories(basePackageClasses = [TokenUsageAggregateRepository::class])
+    @EntityScan(basePackageClasses = [TokenUsageAggregateEntity::class])
+    class Config
+}


### PR DESCRIPTION
- Add Flyway migration and JPA entity/repository for token usage aggregates.
- Refactor token usage store to persist and read user-scoped aggregate usage.
- Add usage context propagation through listener, services, controllers, and streaming paths.
- Update usage endpoints/DTOs for current-user totals and breakdowns.
- Add focused JPA, store, listener, and controller/service tests; run Maven tests.