### PR TITLE
feat(db): secretary_task Flyway V3

### DIFF
--- a/src/main/resources/db/migration/V3__create_secretary_task.sql
+++ b/src/main/resources/db/migration/V3__create_secretary_task.sql
@@ -1,0 +1,23 @@
+CREATE TABLE secretary_task (
+    id                   UUID         NOT NULL,
+    user_id              VARCHAR(128) NOT NULL,
+    chat_id              VARCHAR(128) NOT NULL,
+    title                VARCHAR(512) NOT NULL,
+    description          TEXT,
+    status               VARCHAR(32)  NOT NULL,
+    assigned_agent_id    VARCHAR(64),
+    delegated_brief      TEXT,
+    result_summary       TEXT,
+    error_message        TEXT,
+    requires_confirmation BOOLEAN     NOT NULL DEFAULT FALSE,
+    acceptance_criteria  TEXT,
+    sort_order           INT          NOT NULL DEFAULT 0,
+    list_version         INT          NOT NULL DEFAULT 0,
+    artifacts_json       TEXT,
+    created_at           TIMESTAMPTZ  NOT NULL,
+    updated_at           TIMESTAMPTZ  NOT NULL,
+    CONSTRAINT pk_secretary_task PRIMARY KEY (id)
+);
+
+CREATE INDEX idx_secretary_task_user_chat ON secretary_task (user_id, chat_id);
+CREATE INDEX idx_secretary_task_chat_order ON secretary_task (chat_id, sort_order);


### PR DESCRIPTION
Adds `secretary_task` table for the secretary task ledger.

Stacked split PR 1/3. Merge before `pr/secretary-domain-workers`.

Made with [Cursor](https://cursor.com)