### PR TITLE
feat(chat): default chat via secretary; coach stays direct

### DIFF
--- a/src/main/kotlin/no/josefus/abuhint/controller/CoachAssistantController.kt
+++ b/src/main/kotlin/no/josefus/abuhint/controller/CoachAssistantController.kt
@@ -82,7 +82,7 @@ class CoachAssistantController(
         @RequestBody message: ChatRequest,
     ): ResponseEntity<List<OpenAiCompatibleContentItem>> {
         val sessionId = chatId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
-        val reply = chatService.processChat(
+        val reply = chatService.processCoachChat(
             sessionId,
             message.message,
             usageContext(sessionId, "COACH", clientPlatform),
@@ -102,7 +102,7 @@ class CoachAssistantController(
         @RequestBody message: ChatRequest,
     ): SseEmitter {
         val sessionId = chatId?.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString()
-        return chatService.processChatStream(
+        return chatService.processCoachChatStream(
             sessionId,
             message.message,
             usageContext(sessionId, "COACH", clientPlatform),

--- a/src/main/kotlin/no/josefus/abuhint/service/ChatService.kt
+++ b/src/main/kotlin/no/josefus/abuhint/service/ChatService.kt
@@ -1,16 +1,15 @@
 package no.josefus.abuhint.service
 
-import dev.langchain4j.data.message.AiMessage
 import dev.langchain4j.data.message.ChatMessage
-import dev.langchain4j.data.message.SystemMessage
-import dev.langchain4j.data.message.UserMessage
 import dev.langchain4j.data.segment.TextSegment
 import dev.langchain4j.service.TokenStream
 import dev.langchain4j.store.embedding.EmbeddingMatch
 import java.util.UUID
 import no.josefus.abuhint.repository.ConcretePineconeChatMemoryStore
 import no.josefus.abuhint.repository.LangChain4jAssistant
+import no.josefus.abuhint.repository.SecretaryAssistant
 import no.josefus.abuhint.repository.TechAdvisorAssistant
+import no.josefus.abuhint.secretary.SecretaryChatIds
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
@@ -19,12 +18,14 @@ import java.util.concurrent.atomic.AtomicBoolean
 @Service
 class ChatService(
     private val assistant: LangChain4jAssistant,
+    private val secretaryAssistant: SecretaryAssistant,
     private val geminiAssistant: TechAdvisorAssistant,
     private val concretePineconeChatMemoryStore: ConcretePineconeChatMemoryStore,
+    private val memoryContextService: MemoryContextService,
     @Qualifier("openAiTokenizer")
     private val openAiTokenizer: Tokenizer,
     @Qualifier("geminiTokenizer")
-    private val geminiTokenizer: Tokenizer
+    private val geminiTokenizer: Tokenizer,
 ) {
 
     private val log = org.slf4j.LoggerFactory.getLogger(ChatService::class.java)
@@ -52,71 +53,64 @@ class ChatService(
         throw lastException!!
     }
 
-    fun processChat(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): String {
-        val dateTime = java.time.LocalDateTime.now().toString()
-        return processChatInternal(chatId, userMessage, openAiTokenizer, "openai", usageContext) { effectiveChatId, message, uuid ->
-            retryLlmCall { assistant.chat(effectiveChatId, message, uuid, dateTime) }
+    /** Default brukerreise: Sekretær orkestrering (oppgaver + delegering). LangChain-memory bruker `secretary-`-prefiks. */
+    fun processChat(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): String =
+        processOpenAiChatInternal(
+            chatId,
+            userMessage,
+            openAiTokenizer,
+            "openai-secretary",
+            usageContext,
+            assistantMemoryId = SecretaryChatIds::memoryId,
+        ) { effId, msg, uuid, dt ->
+            retryLlmCall { secretaryAssistant.chat(effId, msg, uuid, dt) }
         }
-    }
+
+    /** Direkte coach (Abu-hint) utenom sekretær — brukes av `/api/coach`-endepunkter. */
+    fun processCoachChat(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): String =
+        processOpenAiChatInternal(
+            chatId,
+            userMessage,
+            openAiTokenizer,
+            "openai-coach",
+            usageContext,
+        ) { effId, msg, uuid, dt ->
+            retryLlmCall { assistant.chat(effId, msg, uuid, dt) }
+        }
 
     fun processGeminiChat(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): String {
         val dateTime = java.time.LocalDateTime.now().toString()
-        return processChatInternal(chatId, userMessage, geminiTokenizer, "gemini", usageContext) { effectiveChatId, message, uuid ->
-            retryLlmCall { geminiAssistant.chat(effectiveChatId, message, uuid, dateTime) }
+        return processGeminiChatInternal(chatId, userMessage, geminiTokenizer, "gemini", usageContext) { effectiveChatId, message, uuid, dt ->
+            retryLlmCall { geminiAssistant.chat(effectiveChatId, message, uuid, dt) }
         }
     }
 
-    private fun processChatInternal(
+    private fun processOpenAiChatInternal(
         chatId: String,
         userMessage: String,
         tokenizer: Tokenizer,
         modelLabel: String,
         usageContext: TokenUsageContext?,
-        chatFn: (String, String, String) -> String
+        assistantMemoryId: (String) -> String = { it },
+        chatFn: (String, String, String, String) -> String,
     ): String {
         val uuid = UUID.randomUUID().toString()
-        val maxContextTokens = 5000
-
-        val effectiveChatId = chatId.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString().also {
-            log.warn("No chatId provided; generated session id $it to isolate conversation.")
-        }
-
+        val dateTime = java.time.LocalDateTime.now().toString()
+        val effectiveChatId = memoryContextService.resolveChatId(chatId)
+        val langChainMemoryId = assistantMemoryId(effectiveChatId)
         val retrievalStart = System.nanoTime()
-        val relevantEmbeddingMatches = retrieveRelevantContext(effectiveChatId, userMessage, maxContextTokens, tokenizer)
+        val prepared = memoryContextService.buildFinalUserMessage(langChainMemoryId, userMessage, tokenizer)
         val retrievalMs = (System.nanoTime() - retrievalStart) / 1_000_000
-
-        val relevantMessages = concretePineconeChatMemoryStore.parseResultsToMessages(relevantEmbeddingMatches)
-        val summarizedMessages = summarizeIfLong(relevantMessages, tokenizer, 20, 800)
-        log.info("LatMeasure: retrievalMs={} matches={}", retrievalMs, relevantMessages.size)
-
-        val enhancedMessage = formatMessagesToContext(summarizedMessages)
-        val totalTokensWithUser = tokenizer.estimateTokenCount(enhancedMessage) + tokenizer.estimateTokenCount(userMessage)
-        log.info("Total tokens in message (context + user): $totalTokensWithUser")
-
-        val contextMessages: Int
-        val contextTokens: Int
-        val finalMessage: String
-
-        if (totalTokensWithUser > maxContextTokens) {
-            val trimmedMessages = trimToTokenLimit(relevantMessages, userMessage, maxContextTokens, tokenizer)
-            val trimmedContext = formatMessagesToContext(trimmedMessages)
-            finalMessage = "$trimmedContext\nUser: $userMessage"
-            contextMessages = trimmedMessages.size
-            contextTokens = tokenizer.estimateTokenCount(trimmedContext)
-        } else {
-            finalMessage = "$enhancedMessage\nUser: $userMessage"
-            contextMessages = summarizedMessages.size
-            contextTokens = tokenizer.estimateTokenCount(enhancedMessage)
-        }
+        log.info("LatMeasure: retrievalMs={} matches={}", retrievalMs, prepared.retrievalMatches)
 
         val modelStart = System.nanoTime()
         val effectiveUsageContext = usageContext?.copy(chatId = effectiveChatId)
-        ChatIdContextHolder.set(effectiveChatId)
+        ChatIdContextHolder.set(langChainMemoryId)
         if (effectiveUsageContext != null) {
             TokenUsageContextHolder.set(effectiveUsageContext)
         }
         val response = try {
-            chatFn(effectiveChatId, finalMessage, uuid)
+            chatFn(langChainMemoryId, prepared.finalUserMessage, uuid, dateTime)
         } finally {
             ChatIdContextHolder.clear()
             TokenUsageContextHolder.clear()
@@ -127,33 +121,63 @@ class ChatService(
         val postProcessed = postProcessReply(response)
         logTelemetry(
             model = modelLabel,
-            contextMessages = contextMessages,
-            contextTokens = contextTokens,
+            contextMessages = prepared.retrievalMatches,
+            contextTokens = tokenizer.estimateTokenCount(prepared.finalUserMessage),
             response = postProcessed,
-            retrievalMatches = relevantMessages.size
+            retrievalMatches = prepared.retrievalMatches,
         )
         return postProcessed
     }
 
+    private fun processGeminiChatInternal(
+        chatId: String,
+        userMessage: String,
+        tokenizer: Tokenizer,
+        modelLabel: String,
+        usageContext: TokenUsageContext?,
+        chatFn: (String, String, String, String) -> String,
+    ): String {
+        val uuid = UUID.randomUUID().toString()
+        val dateTime = java.time.LocalDateTime.now().toString()
+        val effectiveChatId = memoryContextService.resolveChatId(chatId)
+        val retrievalStart = System.nanoTime()
+        val prepared = memoryContextService.buildFinalUserMessage(effectiveChatId, userMessage, tokenizer)
+        val retrievalMs = (System.nanoTime() - retrievalStart) / 1_000_000
+        log.info("LatMeasure: retrievalMs={} matches={}", retrievalMs, prepared.retrievalMatches)
 
-    private fun getMessageText(message: ChatMessage): String = ChatMessageUtils.getMessageText(message)
-
-    private fun formatMessagesToContext(messages: List<ChatMessage>): String {
-        if (messages.isEmpty()) return ""
-        val contextBuilder = StringBuilder()
-        contextBuilder.append("Context recap (most recent first). Use citation tags like [memory#1] when referring to these turns:\n")
-        messages.forEachIndexed { index, message ->
-            val text = getMessageText(message)
-            val recencyTag = "[memory#${index + 1}]"
-            when (message) {
-                is UserMessage -> contextBuilder.append("$recencyTag User: $text\n")
-                is AiMessage -> contextBuilder.append("$recencyTag Assistant: $text\n")
-                is SystemMessage -> contextBuilder.append("$recencyTag System: $text\n")
-            }
+        val modelStart = System.nanoTime()
+        val effectiveUsageContext = usageContext?.copy(chatId = effectiveChatId)
+        ChatIdContextHolder.set(effectiveChatId)
+        if (effectiveUsageContext != null) {
+            TokenUsageContextHolder.set(effectiveUsageContext)
         }
-        contextBuilder.append("End of recap.\nCurrent conversation:\n")
-        return contextBuilder.toString()
+        val response = try {
+            chatFn(effectiveChatId, prepared.finalUserMessage, uuid, dateTime)
+        } finally {
+            ChatIdContextHolder.clear()
+            TokenUsageContextHolder.clear()
+        }
+        val modelMs = (System.nanoTime() - modelStart) / 1_000_000
+        log.info("LatMeasure: modelMs={} ({})", modelMs, modelLabel)
+
+        val postProcessed = postProcessReply(response)
+        logTelemetry(
+            model = modelLabel,
+            contextMessages = prepared.retrievalMatches,
+            contextTokens = tokenizer.estimateTokenCount(prepared.finalUserMessage),
+            response = postProcessed,
+            retrievalMatches = prepared.retrievalMatches,
+        )
+        return postProcessed
     }
+
+    fun retrieveRelevantContext(
+        memoryId: String,
+        query: String,
+        maxTokens: Int,
+        tokenizer: Tokenizer,
+    ): List<EmbeddingMatch<TextSegment>> =
+        memoryContextService.retrieveRelevantContext(memoryId, query, maxTokens, tokenizer)
 
     private fun postProcessReply(reply: String): String {
         if (reply.isNullOrBlank()) {
@@ -167,18 +191,15 @@ class ChatService(
     }
 
     private fun truncateAtBoundary(text: String, limit: Int): String {
-        // If inside a code block, find the start of the block and cut before it
         val lastCodeFence = text.lastIndexOf("```", limit)
         val codeBlocksBefore = text.substring(0, lastCodeFence.coerceAtLeast(0)).count("```")
         if (lastCodeFence > 0 && codeBlocksBefore % 2 != 0) {
-            // We're inside an unclosed code block — truncate before it opened
             val openFence = text.lastIndexOf("```", lastCodeFence - 1)
             if (openFence > 0) {
                 return text.substring(0, openFence).trimEnd() + "\n\n..."
             }
         }
 
-        // Find nearest sentence boundary (. ! ? or newline) before the limit
         val searchRegion = text.substring(0, limit)
         val sentenceEnd = searchRegion.lastIndexOfAny(charArrayOf('.', '!', '?', '\n'))
         return if (sentenceEnd > limit / 2) {
@@ -205,7 +226,7 @@ class ChatService(
         contextMessages: Int,
         contextTokens: Int,
         response: String,
-        retrievalMatches: Int
+        retrievalMatches: Int,
     ) {
         val responseChars = response.length
         val responseTokens = (responseChars / 4).coerceAtLeast(1)
@@ -220,90 +241,93 @@ class ChatService(
             contextTokens,
             responseChars,
             responseTokens,
-            hasFollowUpQuestion
+            hasFollowUpQuestion,
         )
     }
 
     /**
-     * Summarize older messages if the list is long, keeping the most recent `keepRecent` messages
-     * verbatim and prepending a brief summary of older content.
+     * Historikk for standard `/api/chat`-flyt (sekretær): samme Pinecone-minne som brukes med [SecretaryChatIds.memoryId].
      */
-    private fun summarizeIfLong(
-        messages: List<ChatMessage>,
-        tokenizer: Tokenizer,
-        keepRecent: Int,
-        summaryCharLimit: Int
-    ): List<ChatMessage> {
-        if (messages.size <= keepRecent) return messages
-
-        val recent = messages.takeLast(keepRecent)
-        val older = messages.dropLast(keepRecent)
-        val summaryText = older.joinToString(" ") { getMessageText(it) }.take(summaryCharLimit)
-        val summary = SystemMessage("Summary of earlier conversation: $summaryText")
-        return listOf(summary) + recent
-    }
-
-
     fun getChatHistory(chatId: String): List<ChatMessage> {
-        return concretePineconeChatMemoryStore.getMessages(chatId)
+        val effectiveChatId = memoryContextService.resolveChatId(chatId)
+        val memoryId = SecretaryChatIds.memoryId(effectiveChatId)
+        return concretePineconeChatMemoryStore.getMessages(memoryId)
     }
 
-    fun retrieveRelevantContext(
-        memoryId: String,
-        query: String,
-        maxTokens: Int,
-        tokenizer: Tokenizer
-    ): List<EmbeddingMatch<TextSegment>> {
-        val hasHistory = concretePineconeChatMemoryStore.hasStoredMessages(memoryId)
-        if (!hasHistory) {
-            val logger = org.slf4j.LoggerFactory.getLogger(ChatService::class.java)
-            logger.info("No stored messages for chatId=$memoryId; skipping retrieval to avoid cold-start latency")
-            return emptyList()
+    fun processChatStream(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): SseEmitter =
+        streamFromOpenAiAssistant(
+            chatId,
+            userMessage,
+            openAiTokenizer,
+            usageContext,
+            assistantMemoryId = SecretaryChatIds::memoryId,
+        ) { effId, finalMsg, uuid, dt ->
+            secretaryAssistant.chatStream(effId, finalMsg, uuid, dt)
         }
-        return concretePineconeChatMemoryStore.retrieveFromPineconeWithTokenLimit(memoryId, query, maxTokens, tokenizer)
-    }
 
-    fun processChatStream(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): SseEmitter {
-        return streamFromAssistant(chatId, userMessage, openAiTokenizer, usageContext) { effectiveChatId, enhancedMessage, uuid ->
-            val dateTime = java.time.LocalDateTime.now().toString()
-            assistant.chatStream(effectiveChatId, enhancedMessage, uuid)
+    fun processCoachChatStream(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): SseEmitter =
+        streamFromOpenAiAssistant(chatId, userMessage, openAiTokenizer, usageContext) { effId, finalMsg, uuid, _ ->
+            assistant.chatStream(effId, finalMsg, uuid)
         }
-    }
 
     fun processGeminiChatStream(chatId: String, userMessage: String, usageContext: TokenUsageContext? = null): SseEmitter {
-        return streamFromAssistant(chatId, userMessage, geminiTokenizer, usageContext) { effectiveChatId, enhancedMessage, uuid ->
-            val dateTime = java.time.LocalDateTime.now().toString()
-            geminiAssistant.chatStream(effectiveChatId, enhancedMessage, uuid, dateTime)
+        return streamFromGeminiAssistant(chatId, userMessage, geminiTokenizer, usageContext) { effId, finalMsg, uuid, dt ->
+            geminiAssistant.chatStream(effId, finalMsg, uuid, dt)
         }
     }
 
-    private fun streamFromAssistant(
+    private fun streamFromOpenAiAssistant(
         chatId: String,
         userMessage: String,
         tokenizer: Tokenizer,
         usageContext: TokenUsageContext?,
-        streamFactory: (String, String, String) -> TokenStream
+        assistantMemoryId: (String) -> String = { it },
+        streamFactory: (String, String, String, String) -> TokenStream,
     ): SseEmitter {
         val emitter = SseEmitter(120_000L)
         val uuid = UUID.randomUUID().toString()
-        val maxContextTokens = 5000
+        val dateTime = java.time.LocalDateTime.now().toString()
+        val effectiveChatId = memoryContextService.resolveChatId(chatId)
+        val langChainMemoryId = assistantMemoryId(effectiveChatId)
+        val prepared = memoryContextService.buildFinalUserMessage(langChainMemoryId, userMessage, tokenizer)
+        val finalMessage = prepared.finalUserMessage
 
-        val effectiveChatId = chatId.takeIf { it.isNotBlank() } ?: UUID.randomUUID().toString().also {
-            log.warn("No chatId provided; generated session id $it to isolate conversation.")
+        val effectiveUsageContext = usageContext?.copy(chatId = effectiveChatId)
+        val cleanedUp = AtomicBoolean(false)
+
+        fun cleanup() {
+            if (!cleanedUp.compareAndSet(false, true)) return
+            ChatIdContextHolder.clear()
+            TokenUsageContextHolder.clear()
         }
 
-        val relevantEmbeddingMatches = retrieveRelevantContext(effectiveChatId, userMessage, maxContextTokens, tokenizer)
-        val relevantMessages = concretePineconeChatMemoryStore.parseResultsToMessages(relevantEmbeddingMatches)
-        val summarizedMessages = summarizeIfLong(relevantMessages, tokenizer, 20, 800)
-        val enhancedMessage = formatMessagesToContext(summarizedMessages)
-
-        val totalTokens = tokenizer.estimateTokenCount(enhancedMessage) + tokenizer.estimateTokenCount(userMessage)
-        val finalMessage = if (totalTokens > maxContextTokens) {
-            val trimmedMessages = trimToTokenLimit(relevantMessages, userMessage, maxContextTokens, tokenizer)
-            "${formatMessagesToContext(trimmedMessages)}\nUser: $userMessage"
-        } else {
-            "$enhancedMessage\nUser: $userMessage"
+        ChatIdContextHolder.set(langChainMemoryId)
+        if (effectiveUsageContext != null) {
+            TokenUsageContextHolder.set(effectiveUsageContext)
         }
+        val tokenStream = try {
+            streamFactory(langChainMemoryId, finalMessage, uuid, dateTime)
+        } catch (e: Exception) {
+            cleanup()
+            throw e
+        }
+        attachTokenStreamHandlers(emitter, tokenStream, { cleanup() }, effectiveChatId)
+        return emitter
+    }
+
+    private fun streamFromGeminiAssistant(
+        chatId: String,
+        userMessage: String,
+        tokenizer: Tokenizer,
+        usageContext: TokenUsageContext?,
+        streamFactory: (String, String, String, String) -> TokenStream,
+    ): SseEmitter {
+        val emitter = SseEmitter(120_000L)
+        val uuid = UUID.randomUUID().toString()
+        val dateTime = java.time.LocalDateTime.now().toString()
+        val effectiveChatId = memoryContextService.resolveChatId(chatId)
+        val prepared = memoryContextService.buildFinalUserMessage(effectiveChatId, userMessage, tokenizer)
+        val finalMessage = prepared.finalUserMessage
 
         val effectiveUsageContext = usageContext?.copy(chatId = effectiveChatId)
         val cleanedUp = AtomicBoolean(false)
@@ -319,13 +343,22 @@ class ChatService(
             TokenUsageContextHolder.set(effectiveUsageContext)
         }
         val tokenStream = try {
-            streamFactory(effectiveChatId, finalMessage, uuid)
+            streamFactory(effectiveChatId, finalMessage, uuid, dateTime)
         } catch (e: Exception) {
             cleanup()
             throw e
         }
-        val fullResponse = StringBuilder()
+        attachTokenStreamHandlers(emitter, tokenStream, { cleanup() }, effectiveChatId)
+        return emitter
+    }
 
+    private fun attachTokenStreamHandlers(
+        emitter: SseEmitter,
+        tokenStream: TokenStream,
+        cleanup: () -> Unit,
+        effectiveChatId: String,
+    ) {
+        val fullResponse = StringBuilder()
         tokenStream
             .onPartialResponse { token ->
                 try {
@@ -372,26 +405,5 @@ class ChatService(
             log.debug("SSE emitter error for chatId=$effectiveChatId: ${it.message}")
             cleanup()
         }
-
-        return emitter
     }
-
-    private fun trimToTokenLimit(
-        messages: List<ChatMessage>,
-        userMessage: String,
-        maxTokens: Int,
-        tokenizer: Tokenizer
-    ): List<ChatMessage> {
-        val trimmedMessages = mutableListOf<ChatMessage>()
-        var currentTokenCount = tokenizer.estimateTokenCount(userMessage)
-        for (message in messages) {
-            val messageTokens = tokenizer.estimateTokenCount(getMessageText(message))
-            if (currentTokenCount + messageTokens <= maxTokens) {
-                trimmedMessages.add(message)
-                currentTokenCount += messageTokens
-            } else break
-        }
-        return trimmedMessages
-    }
-
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -159,3 +159,9 @@ resend:
         </table>
       </body>
     </html>
+
+abuhint:
+  delegation:
+    embabel-research-spike:
+      # When true, [EmbabelResearchSpikeRunner] runs first for agent `research` (stub until real Embabel wiring).
+      enabled: false


### PR DESCRIPTION
Routes `/api/chat` and OpenAI-compatible `processChat` through SecretaryAssistant with `secretary-` memory ids; `/api/coach` uses LangChain4jAssistant directly.

Depends on PR: secretary domain (`pr/secretary-domain-workers`). Stack 3/3.

Made with [Cursor](https://cursor.com)